### PR TITLE
najdorf: deploy openclaw

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,12 @@
       url = "github:aaddrick/claude-desktop-debian";
       inputs.nixpkgs.follows = "nixos";
     };
+
+    nix-openclaw = {
+      url = "github:openclaw/nix-openclaw";
+      inputs.nixpkgs.follows = "nixos";
+      inputs.home-manager.follows = "home";
+    };
   };
 
   outputs =
@@ -222,6 +228,7 @@
             inputs.agenix.overlays.default
             inputs.deploy.overlays.default
             inputs.nix-minecraft.overlay
+            inputs.nix-openclaw.overlays.default
             (final: prev: {
               hyprland = inputs.hyprland.packages.${prev.stdenv.hostPlatform.system}.hyprland;
               xdg-desktop-portal-hyprland =
@@ -333,6 +340,7 @@
 
             najdorf = mkHost {
               hostname = "najdorf";
+              extraModules = [ inputs.nix-openclaw.nixosModules.openclaw-gateway ];
             };
 
             ginko = mkHost {

--- a/hosts/najdorf/default.nix
+++ b/hosts/najdorf/default.nix
@@ -43,6 +43,7 @@ in
     ./immich.nix
     ./dawarich.nix
     ./actual.nix
+    ./openclaw.nix
 
     # Monitoring & Control
     ./netdata.nix

--- a/hosts/najdorf/openclaw.nix
+++ b/hosts/najdorf/openclaw.nix
@@ -2,13 +2,11 @@
 
 let
   port = 18789;
-  # Under /opt so it's covered by the Restic backup (see default.nix).
-  stateDir = "/opt/openclaw";
 in
 {
   services.openclaw-gateway = {
     enable = true;
-    inherit port stateDir;
+    inherit port;
     config = {
       # localhost only; exposure is handled via Tailscale (see below).
       # najdorf runs without a host firewall, so keep this on loopback.
@@ -18,8 +16,8 @@ in
 
   # Uses a Claude subscription rather than an API key. After the first deploy,
   # register a Claude Code setup-token (generated with `claude setup-token`) as
-  # the gateway's `openclaw` service user:
-  #   sudo -u openclaw OPENCLAW_STATE_DIR=${stateDir} \
+  # the gateway's `openclaw` service user (matching the service's state dir):
+  #   sudo -u openclaw OPENCLAW_STATE_DIR=/var/lib/openclaw \
   #     openclaw models auth paste-token --provider anthropic
   # Setup-tokens (sk-ant-oat...) are static and must be re-pasted when they expire.
 

--- a/hosts/najdorf/openclaw.nix
+++ b/hosts/najdorf/openclaw.nix
@@ -1,46 +1,26 @@
-{ config, ... }:
+{ ... }:
 
 let
-  openclawDir = "/opt/openclaw";
   port = 18789;
-  # OpenClaw's container runs as the unprivileged `node` user (uid/gid 1000),
-  # so the bind-mounted state directories must be owned by it.
-  uid = "1000";
-  gid = "1000";
+  # Under /opt so it's covered by the Restic backup (see default.nix).
+  stateDir = "/opt/openclaw";
 in
 {
-  # Persistent state, owned by the container's `node` user.
-  # - config:  /home/node/.openclaw        (config, agents, auth profiles, workspace)
-  # - secrets: /home/node/.config/openclaw (auth-profile encryption key)
-  systemd.tmpfiles.rules = [
-    "d ${openclawDir}         0750 ${uid} ${gid} - -"
-    "d ${openclawDir}/config  0750 ${uid} ${gid} - -"
-    "d ${openclawDir}/secrets 0700 ${uid} ${gid} - -"
-  ];
-
-  virtualisation.arion.projects.openclaw.settings = {
-    services.openclaw.service = {
-      # `-browser` variant bundles Chromium if you need browser tooling.
-      image = "ghcr.io/openclaw/openclaw:latest";
-      container_name = "openclaw";
-      restart = "unless-stopped";
-      volumes = [
-        "${openclawDir}/config:/home/node/.openclaw"
-        "${openclawDir}/secrets:/home/node/.config/openclaw"
-      ];
-      # Bind to loopback only; exposure is handled via Tailscale (see below).
-      ports = [ "127.0.0.1:${toString port}:${toString port}" ];
-      environment = {
-        OPENCLAW_TZ = config.vars.timezone;
-        # No mDNS discovery inside the container.
-        OPENCLAW_DISABLE_BONJOUR = "1";
-      };
+  services.openclaw-gateway = {
+    enable = true;
+    inherit port stateDir;
+    config = {
+      # localhost only; exposure is handled via Tailscale (see below).
+      # najdorf runs without a host firewall, so keep this on loopback.
+      gateway.bind = "loopback";
     };
   };
 
   # Uses a Claude subscription rather than an API key. After the first deploy,
-  # register a Claude Code setup-token (generated with `claude setup-token`):
-  #   docker exec -it openclaw openclaw models auth paste-token --provider anthropic
+  # register a Claude Code setup-token (generated with `claude setup-token`) as
+  # the gateway's `openclaw` service user:
+  #   sudo -u openclaw OPENCLAW_STATE_DIR=${stateDir} \
+  #     openclaw models auth paste-token --provider anthropic
   # Setup-tokens (sk-ant-oat...) are static and must be re-pasted when they expire.
 
   # TODO: https://github.com/tailscale/tailscale/issues/18381

--- a/hosts/najdorf/openclaw.nix
+++ b/hosts/najdorf/openclaw.nix
@@ -1,0 +1,49 @@
+{ config, ... }:
+
+let
+  openclawDir = "/opt/openclaw";
+  port = 18789;
+  # OpenClaw's container runs as the unprivileged `node` user (uid/gid 1000),
+  # so the bind-mounted state directories must be owned by it.
+  uid = "1000";
+  gid = "1000";
+in
+{
+  # Persistent state, owned by the container's `node` user.
+  # - config:  /home/node/.openclaw        (config, agents, auth profiles, workspace)
+  # - secrets: /home/node/.config/openclaw (auth-profile encryption key)
+  systemd.tmpfiles.rules = [
+    "d ${openclawDir}         0750 ${uid} ${gid} - -"
+    "d ${openclawDir}/config  0750 ${uid} ${gid} - -"
+    "d ${openclawDir}/secrets 0700 ${uid} ${gid} - -"
+  ];
+
+  virtualisation.arion.projects.openclaw.settings = {
+    services.openclaw.service = {
+      # `-browser` variant bundles Chromium if you need browser tooling.
+      image = "ghcr.io/openclaw/openclaw:latest";
+      container_name = "openclaw";
+      restart = "unless-stopped";
+      volumes = [
+        "${openclawDir}/config:/home/node/.openclaw"
+        "${openclawDir}/secrets:/home/node/.config/openclaw"
+      ];
+      # Bind to loopback only; exposure is handled via Tailscale (see below).
+      ports = [ "127.0.0.1:${toString port}:${toString port}" ];
+      environment = {
+        OPENCLAW_TZ = config.vars.timezone;
+        # No mDNS discovery inside the container.
+        OPENCLAW_DISABLE_BONJOUR = "1";
+      };
+    };
+  };
+
+  # Uses a Claude subscription rather than an API key. After the first deploy,
+  # register a Claude Code setup-token (generated with `claude setup-token`):
+  #   docker exec -it openclaw openclaw models auth paste-token --provider anthropic
+  # Setup-tokens (sk-ant-oat...) are static and must be re-pasted when they expire.
+
+  # TODO: https://github.com/tailscale/tailscale/issues/18381
+  # services.tailscale.serve.services.openclaw.https."443" =
+  #   "http://localhost:${toString port}";
+}


### PR DESCRIPTION
Deploys [OpenClaw](https://openclaw.ai/), the self-hosted personal AI assistant, on najdorf using upstream's first-party [`nix-openclaw`](https://github.com/openclaw/nix-openclaw) flake, authenticated with a **Claude subscription** (setup-token) rather than an API key.

## What's here

- **`flake.nix`**
  - New `nix-openclaw` input (following `nixos` / `home`).
  - `nix-openclaw.overlays.default` added to the overlay list (provides `pkgs.openclaw`).
  - `nixosModules.openclaw-gateway` added to najdorf's `extraModules`.
- **`hosts/najdorf/openclaw.nix`** — enables `services.openclaw-gateway`:
  - Runs the gateway as a **system service** (dedicated `openclaw` user), like every other najdorf service — starts at boot, lives in the `system` deploy profile.
  - `gateway.bind = "loopback"` — localhost only. najdorf runs without a host firewall, so this keeps it off the LAN; exposure is via Tailscale.
  - Default `stateDir` (`/var/lib/openclaw`), port `18789`.
- Wired into `hosts/najdorf/default.nix` imports.

## Why the NixOS module (not the Home Manager one)

Upstream exposes both `homeManagerModules.openclaw` (systemd **user** service, batteries-included, desktop-app oriented) and `nixosModules.openclaw-gateway` (systemd **system** service). For a headless server the gateway module is the better fit: no `enable-linger` workaround, and it sits in the same `system` profile and mental model as traefik/immich/dawarich.

## Claude subscription auth

No API key. After the first deploy, register a Claude Code setup-token (from `claude setup-token`) as the gateway's service user:

```
sudo -u openclaw OPENCLAW_STATE_DIR=/var/lib/openclaw \
  openclaw models auth paste-token --provider anthropic
```

Setup-tokens (`sk-ant-oat…`) are static and must be re-pasted when they expire. The default model can then be selected via the Control UI (over Tailscale) or CLI.

## Serving

As requested, this does **not** wire up Tailscale/Traefik — the gateway listens on `127.0.0.1:18789` and the commented `services.tailscale.serve.services.openclaw` line is left in place (matching every other service, still gated on tailscale/tailscale#18381) for you to enable yourself.

## Notes

- State lives at the module default `/var/lib/openclaw`, which is **outside** the Restic `/opt` backup — OpenClaw state (incl. the pasted token) is not backed up. Add `/var/lib/openclaw` to `restic.backups.opt.paths` if you want it covered.

## ⚠️ Before deploying

- **`flake.lock` is not updated.** This sandbox's network policy blocks fetching the new input (`nix flake lock` → HTTP 403 from the proxy), so the lock has no `nix-openclaw` entry yet. Run `nix flake lock` locally before `deploy '.#najdorf'`.
- For the same reason I **couldn't `nix eval`** the config end-to-end here. `nix-instantiate --parse` passes on all changed files, and the wiring follows the module's documented option surface (`services.openclaw-gateway.{enable,port,config}` + `config.gateway.bind`), but it hasn't been evaluated against real inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nUKKRKFcQ3aQz1ermWSND